### PR TITLE
fix monad keystore command

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,11 +286,11 @@ If transactions fail with status `0`:
   - Extract your keystores using the `monad-keystore` binary (v0.11.2) and use the keystore files at `/home/monad/monad-bft/config/id-{bls,secp}` for the commands.
    ```sh
   source /home/monad/.env
-  monad keystore --keystore-path /home/monad/monad-bft/config/id-secp --password "$KEYSTORE_PASSWORD" --key-type secp
+  monad-keystore recover --keystore-path /home/monad/monad-bft/config/id-secp --password "$KEYSTORE_PASSWORD" --key-type secp
   ```
   ```sh
   source /home/monad/.env
-  monad keystore --keystore-path /home/monad/monad-bft/config/id-bls --password "$KEYSTORE_PASSWORD" --key-type bls
+  monad-keystore recover --keystore-path /home/monad/monad-bft/config/id-bls --password "$KEYSTORE_PASSWORD" --key-type bls
   ```
 
   ### CLI workflow:


### PR DESCRIPTION
It seems to be a typo. The main `monad` command does not have a `keystore` subcommand. 