### PR TITLE
feat: pipx install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
 
 [project.urls]
 
+[project.scripts]
+monad-staking-cli = "staking_sdk_py.cli:main"
+
 [tool.hatch.version]
 path = "src/staking_sdk_py/__about__.py"
 
@@ -57,3 +60,6 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/staking_sdk_py"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"staking-cli" = "share/staking-cli"

--- a/src/staking_sdk_py/cli.py
+++ b/src/staking_sdk_py/cli.py
@@ -1,0 +1,71 @@
+"""CLI entry point for staking-sdk-cli."""
+import sys
+import os
+from pathlib import Path
+
+def find_cli_directory():
+    """Find the staking-cli directory in various possible locations."""
+    # Try 1: Relative to this file (development)
+    package_dir = Path(__file__).parent.parent.parent
+    cli_dir = package_dir / 'staking-cli'
+    if cli_dir.exists():
+        return cli_dir
+
+    # Try 2: In the installed package location
+    try:
+        import staking_sdk_py
+        package_location = Path(staking_sdk_py.__file__).parent.parent
+        cli_dir = package_location / 'staking-cli'
+        if cli_dir.exists():
+            return cli_dir
+    except Exception:
+        pass
+
+    # Try 3: In share/staking-cli (if installed via shared-data)
+    # pipx installs packages in ~/.local/pipx/venvs/<package>/share/<package>/
+    try:
+        import site
+        import sysconfig
+        # Try to find share directory in various locations
+        for path in site.getsitepackages() + [sysconfig.get_path('data')]:
+            share_dir = Path(path).parent / 'share' / 'staking-cli'
+            if share_dir.exists():
+                return share_dir
+        # Also try relative to package
+        import staking_sdk_py
+        package_location = Path(staking_sdk_py.__file__).parent.parent
+        share_dir = package_location.parent / 'share' / 'staking-cli'
+        if share_dir.exists():
+            return share_dir
+    except Exception:
+        pass
+
+    # Try 4: Current directory (for development)
+    cwd_cli = Path.cwd() / 'staking-cli'
+    if cwd_cli.exists():
+        return cwd_cli
+
+    raise ImportError(
+        f"Could not find staking-cli directory. "
+        f"Tried: {package_dir / 'staking-cli'}, "
+        f"installed package location, and current directory."
+    )
+
+cli_dir = find_cli_directory()
+sys.path.insert(0, str(cli_dir))
+# Change to the CLI directory so relative imports work
+original_cwd = os.getcwd()
+try:
+    os.chdir(cli_dir)
+    from main import StakingCLI
+finally:
+    os.chdir(original_cwd)
+
+
+def main():
+    """Entry point for the staking-cli console script."""
+    StakingCLI().main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Allow users to easily install the cli tool using pipx
That will avoid having to install a venv, activate it, clone repo, install requirements...

```
pipx install git+https://github.com/monad-developers/staking-sdk-cli.git
```

Users will be able to upgrade versions simply doing
```
pipx upgrade --force staking-sdk-py
```
pipx won't be able to discover the version when calling for an upgrade, so we need to `--force`, but will show whatever is on `src/staking_sdk_py/__about__.py` after installing

Also, it'll allow to run the tool without installing
```
pipx run --spec git+https://github.com/monad-developers/staking-sdk-cli.git monad-staking-cli
```

Ideally a GH release action should be available so versioning can be do over tags, instead of the version file
That will allow to drop the `--force` option